### PR TITLE
Updated deprecated methods and global theme settings for buttons and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 Vertex is a self-hosted chat application based on WebRTC and is built with Flutter for the front end and Python for the backend.
 
 ### Requirements
+[Flutter 3.0.0 • Stable Channel](https://docs.flutter.dev/get-started/install)
 
-`Flutter 3.0.0 • Stable Channel`
-`Dart 2.17.0`
+[Backend Server](https://github.com/VertexChat/norton)
+
+[WebRTC Signalling Server](https://github.com/VertexChat/webrtc-signalling-server)
+
+### How to run
+To list devices you can run the application on with Flutter run:<br>
+* `flutter devices`<br>
+
+Followed by then
+
+* `flutter run -d <device name>`
 
 ### Development & Testing
 This project was developed and tested using:

--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -46,7 +46,43 @@ class _UIState extends State<UI> {
     /// Gives us access to routing, context, and meta info functionality.
     return MaterialApp(
           title: 'Vertex',
-          theme: ThemeData(brightness: Brightness.dark),
+          theme: ThemeData(
+              brightness: Brightness.dark,
+            textTheme: const TextTheme(
+              headline1: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+              ),
+              headline2: TextStyle(
+                color: Colors.white, fontSize: 18,
+              ),
+              headline3: TextStyle(
+                color: Colors.red, fontWeight: FontWeight.bold,
+              ),
+              bodyText1: TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.bold
+              ),
+            ),
+
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                  primary:  Colors.black26,
+                  padding: EdgeInsets.all(8.0),
+              )
+            ),
+
+            elevatedButtonTheme: ElevatedButtonThemeData(
+              style: ElevatedButton.styleFrom(
+                  primary:  Colors.black26,
+                  padding: EdgeInsets.all(8.0),
+
+              )
+            )
+
+          ),
           //home: _defaultRoute,
           debugShowCheckedModeBanner: false,
           // Build that will also handle routing for us as its built into flutter

--- a/ui/lib/src/pages/edit_channel/edit_channel.dart
+++ b/ui/lib/src/pages/edit_channel/edit_channel.dart
@@ -39,10 +39,7 @@ class _EditChannelState extends State<EditChannel> {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               Text("CHANNEL OVERVIEW",
-                  style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white)),
+                  style: Theme.of(context).textTheme.headline2),
               ChannelNavigationOptionsWidget(
                   channel: channel, isVoiceChannel: true),
             ],
@@ -89,29 +86,23 @@ class _EditChannelState extends State<EditChannel> {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: <Widget>[
-                          RaisedButton(
-                            color: Colors.black26,
+                          ElevatedButton(
                             child: Text(
                               "Delete Channel",
-                              style: TextStyle(
-                                  color: Colors.red,
-                                  fontWeight: FontWeight.bold),
-                            ),
+                              style: Theme.of(context).textTheme.headline3),
                             onPressed: () => _showWarningDialog(),
                           ),
-                          RaisedButton(
+                          ElevatedButton(
                             child: Text(
                               "UPDATE",
-                              style: TextStyle(
-                                color: Colors.white,
-                              ),
+                              style: Theme.of(context).textTheme.headline2,
+
                             ),
                             onPressed: () {
                               if (_key.currentState.validate())
                                 _key.currentState.save();
                               updatedChannel(channel.id, channel);
                             },
-                            color: Colors.black26,
                           )
                         ],
                       )
@@ -133,25 +124,24 @@ class _EditChannelState extends State<EditChannel> {
         // return object of type Dialog
         return AlertDialog(
           title: new Text("Delete Channel",
-              style: TextStyle(color: Colors.red, fontWeight: FontWeight.bold)),
+              style: Theme.of(context).textTheme.headline3,),
           content: new Text(
               "Are you sure you want to delete '${channel.name}'? This cannot be undone."),
           actions: <Widget>[
             // usually buttons at the bottom of the dialog
-            new FlatButton(
-              padding: EdgeInsets.all(8.0),
-              child: new Text("Close"),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: new TextButton(
+                child: new Text("Close"),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
             ),
-            new FlatButton(
-              padding: EdgeInsets.all(8.0),
-              color: Colors.red,
+            new TextButton(
               child: new Text(
                 "Delete Channel",
-                style:
-                    TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                style: Theme.of(context).textTheme.headline2,
               ),
               onPressed: () => deleteChannel(channel.id),
             ),

--- a/ui/lib/src/pages/home/home_card_widget.dart
+++ b/ui/lib/src/pages/home/home_card_widget.dart
@@ -22,50 +22,32 @@ class HomeCardWidget extends StatelessWidget {
                     child: Column(
                       children: <Widget>[
                         Icon(
-                          FontAwesomeIcons.smile,
+                          FontAwesomeIcons.faceSmile,
                         ),
                         Text(
                           "Friends",
-                          style: TextStyle(
-                              fontSize: 11, fontWeight: FontWeight.bold),
+                          style: Theme.of(context).textTheme.bodyText1
                         ),
                       ],
                     ),
                   ),
                   // Friend query heading
-                  RaisedButton(
-                    padding: EdgeInsets.all(8.0),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: new BorderRadius.circular(10.0),
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ElevatedButton(
+                      onPressed: () => null,
+                      child: Text("Online"),
                     ),
-                    color: Colors.black12,
-                    onPressed: () => null,
-                    child: Text("Online"),
                   ),
-                  RaisedButton(
-                    padding: EdgeInsets.all(8.0),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: new BorderRadius.circular(10.0),
-                    ),
-                    color: Colors.black12,
+                  ElevatedButton(
                     onPressed: () => null,
                     child: Text("Pending"),
                   ),
-                  RaisedButton(
-                    padding: EdgeInsets.all(8.0),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: new BorderRadius.circular(10.0),
-                    ),
-                    color: Colors.black12,
+                  ElevatedButton(
                     onPressed: () => null,
                     child: Text("Blocked"),
                   ),
-                  RaisedButton(
-                    padding: EdgeInsets.all(8.0),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: new BorderRadius.circular(10.0),
-                    ),
-                    color: Colors.green,
+                  ElevatedButton(
                     onPressed: () => null,
                     child: Text("Add Friend"),
                   )

--- a/ui/lib/src/pages/home/home_view_web.dart
+++ b/ui/lib/src/pages/home/home_view_web.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:vertex_ui/src/pages/layout_template/home_layout_template.dart';
 import 'package:vertex_ui/src/widgets/main_app_widgets/app_navigation_bar.dart';

--- a/ui/lib/src/pages/login/login_page.dart
+++ b/ui/lib/src/pages/login/login_page.dart
@@ -29,7 +29,7 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage>
     implements LoginScreenContract, AuthStateListener {
   //Member Variables
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final GlobalKey<ScaffoldMessengerState> _scaffoldKey = new GlobalKey<ScaffoldMessengerState>();
   final formKey = GlobalKey<FormState>();
   InlineObject _login = InlineObject();
   LoginScreenPresenter _presenter;
@@ -192,8 +192,10 @@ class _LoginPageState extends State<LoginPage>
             elevation: 5.0,
             child: StreamBuilder<bool>(
               stream: bloc.submitCheck,
-              builder: (context, snapshot) => RaisedButton(
-                color: Colors.green,
+              builder: (context, snapshot) => ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                    primary: Colors.green
+                ),
                 onPressed: () => _submit(),
                 child: Center(
                   child: Text(

--- a/ui/lib/src/pages/register/register_page.dart
+++ b/ui/lib/src/pages/register/register_page.dart
@@ -18,7 +18,7 @@ class _RegisterPageState extends State<RegisterPage>
   // Create a global key that uniquely identifies the Form widget
   // and allows validation of the form.
   final formKey = GlobalKey<FormState>();
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final GlobalKey<ScaffoldMessengerState> _scaffoldKey = new GlobalKey<ScaffoldMessengerState>();
   bool _validate = false;
   InlineObject user = InlineObject();
   RegisterScreenPresenter _presenter;
@@ -129,8 +129,10 @@ class _RegisterPageState extends State<RegisterPage>
               elevation: 7.0,
               child: StreamBuilder<bool>(
                 stream: bloc.submitCheck,
-                builder: (context, snapshot) => RaisedButton(
-                  color: Colors.green,
+                builder: (context, snapshot) => ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    primary:  Colors.green,
+                  ),
                   onPressed: () => _submit(),
                   child: Center(
                     child: Text(

--- a/ui/lib/src/pages/settings/app_info.dart
+++ b/ui/lib/src/pages/settings/app_info.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info/package_info.dart';
 

--- a/ui/lib/src/pages/settings/settings_view_mobile.dart
+++ b/ui/lib/src/pages/settings/settings_view_mobile.dart
@@ -3,10 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:vertex_ui/src/pages/settings/app_info.dart';
-import 'package:vertex_ui/src/widgets/settings_widgets/mute_card_widget.dart';
 import 'package:vertex_ui/src/widgets/settings_widgets/settings_card_widget.dart';
 import 'package:vertex_ui/src/widgets/settings_widgets/user_details_widget.dart';
-import 'package:vertex_ui/src/widgets/settings_widgets/text_widget.dart';
 
 ///  Main Settings view for mobile device
 class SettingsViewMobilePortrait extends StatefulWidget {

--- a/ui/lib/src/pages/settings/settings_view_web.dart
+++ b/ui/lib/src/pages/settings/settings_view_web.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:vertex_ui/src/widgets/settings_widgets/mute_card_widget.dart';
 import 'package:vertex_ui/src/widgets/settings_widgets/settings_card_widget.dart';
 import 'package:vertex_ui/src/widgets/settings_widgets/user_details_widget.dart';
 import 'package:vertex_ui/src/widgets/settings_widgets/text_widget.dart';
@@ -355,7 +353,7 @@ class _SettingsViewWeb extends State<SettingsViewWeb> {
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
                     "VOICE SETTINGS",
-                    style: TextStyle(fontWeight: FontWeight.bold),
+                    style: Theme.of(context).textTheme.bodyText2
                   ),
                 ),
                 Row(
@@ -384,13 +382,13 @@ class _SettingsViewWeb extends State<SettingsViewWeb> {
                     optionsDropdownBox: videoInputDropBox,
                     settingsTypeHeading: "Webcam Device"),
                 // Audio Mute Settings output & input
-                MuteCard(
-                  audioMuteToggle: audioInputIsMuteToggle,
-                  muteSourceTypeHeading: "Mute Audio Input",
+                SettingsCard(
+                  optionsDropdownBox: audioInputIsMuteToggle,
+                  settingsTypeHeading: "Mute Audio Input",
                 ),
-                MuteCard(
-                  audioMuteToggle: audioOutputIsMuteToggle,
-                  muteSourceTypeHeading: "Mute Audio Output",
+                SettingsCard(
+                  optionsDropdownBox: audioOutputIsMuteToggle,
+                  settingsTypeHeading: "Mute Audio Output",
                 )
               ],
             ),

--- a/ui/lib/src/pages/splash_screen.dart
+++ b/ui/lib/src/pages/splash_screen.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
 import 'package:vertex_ui/src/widgets/main_app_widgets/custom_gradient.dart';
 
 import 'home/home_page.dart';

--- a/ui/lib/src/pages/video_call/video_call_page.dart
+++ b/ui/lib/src/pages/video_call/video_call_page.dart
@@ -282,8 +282,11 @@ class _VideoCallPageState extends State<VideoCallPage> {
                           return _buildRow(_peers[i]);
                         })
                     : Center(
-                        child: Text(
-                            "Unable to connect to server. Please refresh to try again or contact support"),
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                              "Unable to connect to server. Please refresh to try again or contact support"),
+                        ),
                       ));
   } //end Widget build
 } //End class

--- a/ui/lib/src/services/authentication.dart
+++ b/ui/lib/src/services/authentication.dart
@@ -20,7 +20,7 @@ class AuthStateProvider {
   factory AuthStateProvider() => _instance;
 
   AuthStateProvider.internal() {
-    _subscribers = new List<AuthStateListener>();
+    _subscribers = <AuthStateListener>[];
     initState();
   }
 

--- a/ui/lib/src/services/signaling.dart
+++ b/ui/lib/src/services/signaling.dart
@@ -334,7 +334,8 @@ class Signaling {
     _peerConnections.forEach((key, pc) {
       pc.close();
     });
-    if (_socket != null) _socket.close();
+    if (_socket != null)
+      _socket.close();
   }
 
   /// Fruition creates and returns a [MediaStream]. Depending on the

--- a/ui/lib/src/utils/websocket.dart
+++ b/ui/lib/src/utils/websocket.dart
@@ -75,7 +75,10 @@ class SimpleWebSocket {
   }
 
   close() {
-    _socket.close();
+    if (_socket == null){
+      print('Socket it null');
+    }else
+      _socket.close();
   }
 
   // https://stackoverflow.com/questions/53721745/dart-upgrade-client-socket-to-websocket

--- a/ui/lib/src/widgets/api_exception_alert_dialog.dart
+++ b/ui/lib/src/widgets/api_exception_alert_dialog.dart
@@ -14,6 +14,7 @@ class ApiExceptionAlertDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
     Map<String, dynamic> parsedError =
         json.decode(apiException.message.toString());
 
@@ -22,7 +23,7 @@ class ApiExceptionAlertDialog extends StatelessWidget {
       content: new Text(parsedError['messages']),
       actions: <Widget>[
         // usually buttons at the bottom of the dialog
-        new FlatButton(
+        new TextButton(
           child: new Text("Close"),
           onPressed: () {
             Navigator.of(context).pop();

--- a/ui/lib/src/widgets/exception_alert_dialog.dart
+++ b/ui/lib/src/widgets/exception_alert_dialog.dart
@@ -12,11 +12,11 @@ class ExceptionAlertDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: new Text("Expection"),
+      title: new Text("Exception"),
       content: new Text(exception.toString()),
       actions: <Widget>[
         // usually buttons at the bottom of the dialog
-        new FlatButton(
+        new TextButton(
           child: new Text("Close"),
           onPressed: () {
             Navigator.of(context).pop();

--- a/ui/lib/src/widgets/home_widgets/channel_members_widget.dart
+++ b/ui/lib/src/widgets/home_widgets/channel_members_widget.dart
@@ -70,13 +70,13 @@ class _ChannelMembersWidgetState extends State<ChannelMembersWidget> {
       content: _channelMembersListView(membersList),
       actions: <Widget>[
         // usually buttons at the bottom of the dialog
-        new FlatButton(
+        new TextButton(
           child: new Text("Close"),
           onPressed: () {
             Navigator.of(context).pop();
           },
         ),
-        new FlatButton(
+        new TextButton(
             onPressed: () => showDialog(
                 context: context,
                 builder: (BuildContext content) => _addMemberDialog(context)),
@@ -91,7 +91,7 @@ class _ChannelMembersWidgetState extends State<ChannelMembersWidget> {
       content: _usersListView(),
       actions: <Widget>[
         // usually buttons at the bottom of the dialog
-        new FlatButton(
+        new TextButton(
           child: new Text("Close"),
           onPressed: () {
             Navigator.of(context).pop();

--- a/ui/lib/src/widgets/home_widgets/channel_navigation_options_widget.dart
+++ b/ui/lib/src/widgets/home_widgets/channel_navigation_options_widget.dart
@@ -30,7 +30,7 @@ class ChannelNavigationOptionsWidget extends StatelessWidget {
         isVoiceChannel
             ? Container()
             : IconButton(
-                icon: Icon(FontAwesomeIcons.userFriends),
+                icon: Icon(FontAwesomeIcons.userGroup),
                 onPressed: () => showDialog(
                     context: context,
                     builder:  (BuildContext content) =>
@@ -39,12 +39,12 @@ class ChannelNavigationOptionsWidget extends StatelessWidget {
         SizedBox(width: 25),
         // Button to navigate to landing page
         IconButton(
-            icon: Icon(FontAwesomeIcons.home),
+            icon: Icon(FontAwesomeIcons.house),
             onPressed: () => locatorGlobal<NavigationServiceHome>()
                 .navigateTo(LandingPageRoute)),
         SizedBox(width: 25),
         IconButton(
-            icon: Icon(FontAwesomeIcons.cog),
+            icon: Icon(FontAwesomeIcons.gear),
             onPressed: () => locatorGlobal<NavigationServiceHome>()
                 .navigateTo(EditChannelRoute, arguments: channel)),
       ],

--- a/ui/lib/src/widgets/main_app_widgets/custom_gradient.dart
+++ b/ui/lib/src/widgets/main_app_widgets/custom_gradient.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 
 LinearGradient getCustomGradient() {
   return LinearGradient(

--- a/ui/lib/src/widgets/server_drawer_option/heading_widget.dart
+++ b/ui/lib/src/widgets/server_drawer_option/heading_widget.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:vertex_ui/src/widgets/server_drawer_option/new_channel_dialog_widget.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';

--- a/ui/lib/src/widgets/server_drawer_option/new_channel_dialog_widget.dart
+++ b/ui/lib/src/widgets/server_drawer_option/new_channel_dialog_widget.dart
@@ -41,10 +41,7 @@ class _NewChannelDialogState extends State<NewChannelDialog> {
               children: <Widget>[
                 Text(
                   'CREATE A NEW CHANNEL',
-                  style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                      fontSize: 22),
+                  style: Theme.of(context).textTheme.headline1,
                 ),
                 SizedBox(height: 30),
                 ListTile(
@@ -86,19 +83,15 @@ class _NewChannelDialogState extends State<NewChannelDialog> {
                     crossAxisAlignment: CrossAxisAlignment.center,
                     mainAxisAlignment: MainAxisAlignment.spaceAround,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: Text('Cancel'),
                         onPressed: () =>
                             Navigator.of(context, rootNavigator: true)
                                 .pop('dialog'),
-                        color: Colors.black26,
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: Text(
-                          "CREATE",
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
+                          "Create",
                         ),
                         onPressed: () {
                           if (_key.currentState.validate())
@@ -106,7 +99,6 @@ class _NewChannelDialogState extends State<NewChannelDialog> {
                           channel.id = 0;
                           postNewChannel(channel);
                         },
-                        color: Colors.black26,
                       )
                     ],
                   ),

--- a/ui/lib/src/widgets/server_drawer_option/server_drawer_list_builder.dart
+++ b/ui/lib/src/widgets/server_drawer_option/server_drawer_list_builder.dart
@@ -1,5 +1,4 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:openapi/api.dart';
 import 'package:vertex_ui/locator.dart';
@@ -32,7 +31,7 @@ class ServerDrawerListBuilder extends StatelessWidget {
   /// be used to display either a volume_up icon for voice channels or a message
   /// icon for text channels.
   ///
-  /// The [RaisedButton] onPressed event will [NavigationServiceHome] with the help
+  /// The [ElevatedButton] onPressed event will [NavigationServiceHome] with the help
   /// of a [locatorGlobal] provider to navigate to [VoiceChannelRoute] or [MessageRoute]
   ListView _channelsListView(channelData) {
     return ListView.separated(
@@ -62,8 +61,7 @@ class ServerDrawerListBuilder extends StatelessWidget {
         // Display channels in container
         return Container(
             height: 40,
-            child: RaisedButton(
-                color: Colors.black26,
+            child: ElevatedButton(
                 child: Row(
                   children: <Widget>[
                     Padding(

--- a/ui/lib/src/widgets/server_drawer_option/server_drawer_settings_bar.dart
+++ b/ui/lib/src/widgets/server_drawer_option/server_drawer_settings_bar.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 /// Drawer settings class that returns a widget with buttons that allow

--- a/ui/lib/src/widgets/settings_widgets/settings_card_widget.dart
+++ b/ui/lib/src/widgets/settings_widgets/settings_card_widget.dart
@@ -1,6 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'text_widget.dart';
 
 /// Widget that will create a card widget to display audio options for input device
 /// or output devices depending on the parameters passed

--- a/ui/lib/src/widgets/settings_widgets/user_details_widget.dart
+++ b/ui/lib/src/widgets/settings_widgets/user_details_widget.dart
@@ -19,9 +19,11 @@ class UserDetails extends StatelessWidget {
             leading: Icon(FontAwesomeIcons.user, size: 44.0),
             title: Text(userName,
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-            trailing: RaisedButton(
+            trailing: ElevatedButton(
               child: Text("Logout"),
-              color: Colors.red,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.red
+              ),
               onPressed: () => null,
             ),
           ),


### PR DESCRIPTION
…text. (#25)

* Users can now be added to text channels (#24) (#4)

* Added in-call page

* Added in-call icon buttons

* Code tidy up and button press implemented into icons on the call page

* Added icon assets. Implemented login page with login route for web browser support

* Added register page. Added icon card widget for login & register pages

* Added form validation for user registration

* Added scaling for mobile and web browser. Added auto text scaling package

* Fixed an issue with scaling on the login page. Removed unneeded classes

* Fixed an issue with scaling on the login and register pages

* Added user model. Added NetworkUtil, used for http requests

* Updated .gitignore and updated user model

Added two new ignore to prevent unneeded files being added to the repo as they are auto generated when the application is ran.
+ .flutter-plugins
+ .flutter-plugins-dependencies
* Updated user model class

* Added Client API code that was generated from a OpenAPI design file

+ Models
+ API Routes
+ API Client and helper classes
+ Added HTTP dependence in application config file

* Added Validator class for validating user input for registering

+ Validator class
* Added a constructor with parameter to user model class
* User can now make a register request to the server
* Registration class code tidy up

* Implemented the Bloc pattern with the login page

+ Bloc pattern
+ User can now login with a username & password that is registered in the database
* Updated validator class to work with the bloc pattern
+ Added rxdart package used for stream and streamControllers

* Updated registration page to use the bloc design pattern

+ Bloc design pattern add to the register page
* Code tidy up

* Updated login and register buttons to not allow the user submit unless form fields match validation requirement

* Added submit check in both login and register bloc classes
* Updated login and register UI components to work with submit check
- Removed unneeded dependencies from pubspec

* Backend code named Norton developed in python
+ Swagger API definition.
+ Server stubs generated from Swagger API.
+ Hashing function added for user passwords to store it as a salt and hash in the database.
+ Authentication for user login added to auth controller.
+ User account creation added to user controller

* Implemented snackbar that will display errors to the user if any when they are trying to login. Updated application to support Androidx

+ Added Login screen handler class that handles successful and failed login attempts after a API call is made
* Updated the project to support the Androidx as this was causing issues when running the application in a emulator

* Updated backend

+ Added status codes to responses
+ Added response for duplicate entries of username

* Updated Register to support presenter and snackbar for errors

+ Added presenter class
* Updated register page to implement presenter class

* Removed undeeed images from repo. Updated .gitignore & pubspec

* Updated validator for registration form

* Abstracted the gradient used on pages background as its used in more then one place

* Removed unneeded classes from UI and updated OpenAPI.yaml file to include login and register routes

* Pre stubs

* Implemented a responsive design for the home page. This allows the rendering of the page to work on mobile, tablet and web properly

+ Added response_design package to pubspec.yaml
* Changed home_page to call on the renderer needed for whatever device the application is running on
+ Added home_views for both web and mobile that will display home widgets. These classes will be called when home_page detects the device the application is running on
+ Implemented a app drawer that will display voice channels users can join.
* Abstracted the appbar into its own custom widget
+ Implemented a heading widget that returns a styled heading
- Removed unneeded example class

* Implemented routing classes and refactored and commented classes related to the server app drawer and UI responsive design

+ Routing class that allows routing by using the URL
+ Channel Model class that is used for creating Channel UI elements in the server app drawer
* Refactored class names for the app drawer to server app drawer as it relates to information on a particular server
* Added to comments all new response design classes implemented

* UI scaling changed so elements display better on web and mobile, updated requirements.txt for Norton

* README.md update to include setup sets for Norton

* Implemented responsive design for the settings page on mobile and web

+ Responsive design implemented so the settings page can display correctly on both web view and mobile
* Refactored settings page design to fit mobile and web better
+ Added font awesome flutter icon package to pubspec.yaml

* Refactored and abstracted widgets used in the settings page for mobile and web UI

* Abstracted a Settings Card, Mute Card & User Details widget as its was being used in more then one place

* Implemented device and app information section to settings UI

+ Implemented UI elements for information about the app build number and version as well as information about the device the app is running on
+ Added new two new packages to the pubspec.yaml `device_info` & `package_info`
* Updated the router class to pass Routing settings along with routes

* Fixed a bug with async call

* Updated _fetchPackageInfo method to now update state when information about the device is returned. This fixed a bug with the widget builder reporting a null values on strings

* Fixed two issues with async methods for app information and device information

* Updated app and device classes to use a FutureBuilder to allow for async call to get data

* Fixed minor issue with function call in settings. Added flutter webrtc and rxdart to pubspec.yaml

* Removed unheeded classes from repo

* Added WebRTC signalling class and websocket class

* Implemented a Observer/Subscriber Pattern for the authentication in the application. This allows another class subscribe to the AuthState to know the logged in state of a user. Rebuilt project to support new Android version

+ Implemented auth.dart a Observer/Subscriber pattern class for authentication
* Changed main.dart to now check to see if a user in logged in before they can access the application
* Updated login_page to route correctly
- Removed unneeded files from project
* Updated pubspec.yaml to include a missing package

* Made changes to user information card in settings UI, Card will not display the name of the current user logged into the application

* Updated OpenAPI Design to implement a getAllChannels function. Fixed an issue with the Settings UI restore function

* Updated the settings_view_web.dart to use a FutureBuilder instead of a Widget builder as it needs to fetch data when the page is initialising
* Updated the auth_api.dart to store the current username and id of the user logged in
* Updated the OpenAPI.yaml support a getAllChannels route

* Fixed an issue with the OpenAPI.yaml file

* Updated project file structure and implemented and new route for channel_api.dart

* channel_api.dart now has a getAllChannels route that will return all channels on a server
* client_stubs now has a lib folder
* Fixed imports

* Updated project file structure to match new one

* Fixed a bug with the keyboard not displaying correctly on Android devices and another issue with WebRTC classes not compiling correctly on Android devices

* Missing class for compiling Android WebRTC classes was missing from the project
* FormKey that is needed with a TextField function in the text messaging class was causing the issue with the keyboard

* Updated the OpenAPI.yaml to return an array of channel objects, Regenerated client_stubs to match the OpenAPI.yaml spec

* Fixed an import issue with the signalling class
* Updated client_stubs

* Fixed WebRTC not connecting

* Channels are now pulled from the server and display as UI elements in the drawer_list

+ Added a equals method to allow two strings to be compared
* Updated server_drawer_list_builder.dart to now build a list of channels from the data received from the server

* Changed how the home page now renders widgets to allow for a more robust design and easier navigation for the user. Implemented a voice_call page that will display information about a on-going call to the user.

+ Implemented main_layout_template.dart & home_layout_template.dart that will render a page based on routing & user interactions with navigation buttons.
+ Added a landing_page that displays when the home page loads.
+ Implemented a navigation_service using a locator service package called get_it. Get_it allows for the registration of navigation services in the application using a lazy singleton.
+ Added turn classes for web and mobile to get turn Credentials when trying to connect a call(ref: flutter-web-rtc).
+ Add channel_nane_widget.dart & channel_navigation_options_widget.dart used for displaying channel name and navigation buttons when a user is inside a channel.
* Updated router.dart routes, its now has global routes and internal routes. Internal routes are used with button interactions by the user to navigate and should not be used with URL routing (Global routes can be updated to implement more routes needed for that)
* Updated route_names.dart with new routes.
* Updated websocket.dart to use self signed certs when connecting to a call.
* Update project file structure to tidy up widgets.
* Updated main.dart to init the navigation services when the application starts. Updated MaterialApp to use a builder that will render a view based on a child return from the navigation service.
* Updated pubspec.yaml package, now includes get_it.

* Added missing message stubs for client. Updated OpenAPI.yaml

* Added WebRTC Signalling server to repo, updated applications connections URL to point to Vertex.chat domain

* Updated WebSockets, videos calling class & voice call class to use vertex.chat domain.
+ Added WebRTC signalling server which runs on our server with Nginx handling the routing to allows the application connect to it use https and wss, this is a must for WebRTC to work.
* Updated OpenAPI.yaml spec

* WebRTC server now working to handle handshakes for peers that want to communicate

* Updated WebRTC server to implement handshaking correctly
- Removed connect_call_page.dart
* Updated video_call_page.dart class names
* Updated app_navigation_bar.dart, cam icon now routes to VideoCallPage

* Implemented disconnection case from server for peers on WebRTC server

* When a client send a bye request to the server it will disconnect both clients who were have a p2p call
* Cody tidy and comments added

* Fix with server.ts files

* Minor changes

* Class name fix

* Address update

* Implemented state management so allow for the rebuild of widgets when new data is received from the database. This ties in with the notification system that will alert a user logged in that new data is available from the database

+ view_state_enum.dart - used with base_model.dart to alert UI if widget is busy or not when getting data.
+ base_view.dart which handles widget state.
+ notification_service.dart which will connect to the notification server to update users logged in of changes in the database
+ channel_navigation_options_widget.dart - handles the CRUD operations between the API and widgets, widgets will be updated once an operations is complete.
* Updated channel.dart with missing field
* Updated locator.dart with a new service
- Removed package-lock.json

* Commented code and class, removed unneeded classes

* Updated application name for Android platform, WebRTC server now running on another server

* Updated package in pubspec.yaml#
* Changed the IP address for WebRTC
+ Added Popout dialog box for adding a new channel

* Updated client_stubs, updated register UI elements

* New client stubs generated from openapi.spec to make request to the server(Norton).
* Removed display name from register form as its not used anymore.
* Code tidy up

* A user can now create a voice or text channel

* Updated channels_view_model.dart to allow for a new channel to be created as well as implemented error handling UI elements. Listens are notified of local changes.
 - new_channel_dialog_widget.dart
* Fixed a bug with locator.dart where using a Factory instead of a LazySingleton would break the NotifyListens function for state management.
* Updated README.md

* A user can now edit and delete a channel

+ api_exception_alert_dialog.dart is used to display an api exception message to the user if a request could not be processed.
+ edit_channel.dart class which builds the UI for editing a channel.
* Added new route EditChannelRoute.
* Added a delete function to channels_view_model.dart and changed how then update local data.

* A user can now view members of a channel they are in

+ Created new channel_members_widget.dart UI element to display users in a channel.
+ Created a new exception_alert_dialog.dart to display exceptions to the user if any occur.
+ Implemented a new channel_members_view_model.dart that handles state management for channel members in the channel_members_widget.dart.
+ Injected the channel_members_view_model.dart as a service in the locator.dart.
* Commented classes and function, Code tidy up.

* Users can now send message in a text channel

+ Implemented message_view_model.dart to handle state management for messages
* Updated text_chat_page.dart UI elements and implemented base_view.dart model to retrieve and build message data from the message_view_model.dart
* Updated navigation_service.dart to splash some widget key bugs.
* Added a new package call intl to the pubspec.yaml, it is used to convert time-date stamps.

* Client stubs handled on there own repo now. Imported to application though pubspec.yaml

* Login updated

* Users can now make a p2p voice call when they join a voice channel

* Updated voices channels to allow for peer to peer voice calls using WebRTC
* Updated both voice_call.dart and video_call_page.dart pages to chanel states correctly
+ Abstracted enums to their own class. authentication_enum.dart & signaling_state_enum.dart
* Renamed voice_call to voice_call_page.dart
* Moved signaling.dart into services folder
* Commented code and class tidy ups
- Removed signalling server from this repo as it now as its own one in the org

* Minor bug fixes with UI elements not rendering correctly

* Updated URL for servers, minor changes to fix some UI bugs. Pubspec updated

* Updated README.md

* Users can now be added to text channels

* Code tidy up
* Updated members list view to now allow a user view a list of user and they can add them to the current channel
* Commented code

Co-authored-by: David Neilan <neilan.david@gmail.com>

Co-authored-by: David Neilan <neilan.david@gmail.com>

* Fix some minor deprecation issue and a error message under video_call_page.dart

* Updated deprecated methods and global theme settings for buttons and text.

* Updated README.md

Co-authored-by: David Neilan <neilan.david@gmail.com>